### PR TITLE
docs: fix simple typo, explination -> explanation

### DIFF
--- a/jni/libpng/jni/png.h
+++ b/jni/libpng/jni/png.h
@@ -1976,7 +1976,7 @@ extern PNG_EXPORT(void,png_set_crc_action) PNGARG((png_structp png_ptr,
  * mainly useful for testing, as the defaults should work with most users.
  * Those users who are tight on memory or want faster performance at the
  * expense of compression can modify them.  See the compression library
- * header file (zlib.h) for an explination of the compression functions.
+ * header file (zlib.h) for an explanation of the compression functions.
  */
 
 /* Set the filtering method(s) used by libpng.  Currently, the only valid


### PR DESCRIPTION
There is a small typo in jni/libpng/jni/png.h.

Should read `explanation` rather than `explination`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md